### PR TITLE
Migrate CircleCI ci.yml workflow to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: ci
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  current-go:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.15
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Setup required permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-mod
+        with:
+          path: /home/circleci/go/pkg/mod
+          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+      - name: Precommit and Coverage Report
+        run: |
+          make ci
+          mkdir $TEST_RESULTS/
+          cp coverage.out $TEST_RESULTS/
+          cp coverage.txt $TEST_RESULTS/
+          cp coverage.html $TEST_RESULTS/
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+      - name: store test results
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+  prior-go:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.14
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Setup required permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-mod
+        with:
+          path: /home/circleci/go/pkg/mod
+          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+      - name: Precommit and Coverage Report
+        run: |
+          make ci
+          mkdir $TEST_RESULTS/
+          cp coverage.out $TEST_RESULTS/
+          cp coverage.txt $TEST_RESULTS/
+          cp coverage.html $TEST_RESULTS/
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+      - name: store test results
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   go:
     strategy:
+      fail-fast: false
       matrix:
         container: ["cimg/go:1.14", "cimg/go:1.15"]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,13 @@ on:
   pull_request:
 
 jobs:
-  current-go:
+  go:
+    strategy:
+      matrix:
+        container: ["cimg/go:1.14", "cimg/go:1.15"]
     runs-on: ubuntu-latest
     container:
-      image: cimg/go:1.15
+      image: ${{ matrix.container }}
     env:
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
     steps:
@@ -36,51 +39,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
       - name: store test output
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-      - name: store test results
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-  prior-go:
-    runs-on: ubuntu-latest
-    container:
-      image: cimg/go:1.14
-    env:
-      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
-    steps:
-      - name: Setup required permissions
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: restore cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-go-mod
-        with:
-          path: /home/circleci/go/pkg/mod
-          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
-      - name: Precommit and Coverage Report
-        run: |
-          make ci
-          mkdir $TEST_RESULTS/
-          cp coverage.out $TEST_RESULTS/
-          cp coverage.txt $TEST_RESULTS/
-          cp coverage.html $TEST_RESULTS/
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.txt
-          fail_ci_if_error: true
-          verbose: true
-      - name: store test output
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-      - name: store test results
         uses: actions/upload-artifact@v2
         with:
             name: opentelemetry-go-test-output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct the `Span.End` method documentation in the `otel` API to state updates are not allowed on a span after it has ended. (#1310)
 - Updated span collection limits for attribute, event and link counts to 1000 (#1318)
 - Renamed `semconv.HTTPUrlKey` to `semconv.HTTPURLKey`. (#1338)
+- Migrated CI/CD from CircleCI to GitHub Actions (#ADD_NUMBER_WHEN_PR_IS_MADE)
 
 ### Removed
 


### PR DESCRIPTION
### What does this do

This  addresses issue https://github.com/open-telemetry/opentelemetry-go/issues/880 by migrating CI/CD from CircleCI to GitHub Actions

### Changes

* Migrated `current-go` and `prior-go` CircleCI jobs to GitHub Actions 
* Changelog updated

### Migration Plan
I suggest having CircleCI and GitHub Action jobs run in parallel for a few weeks. After the GitHub Action jobs are running fine for about a week, please remove the CircleCI workflows from `config.yml`

cc- @alolita 