### PR TITLE
Adding Security Workflows to GitHub Actions (2/2): gosec workflow

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,20 @@
+name: Run Gosec
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
+

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,9 +1,5 @@
 name: Run Gosec
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
 jobs:
   tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `NewGRPCDriver` function returns a `ProtocolDriver` that maintains a single gRPC connection to the collector. (#1369)
 - Documentation about the project's versioning policy. (#1388)
 - `NewSplitDriver` for OTLP exporter that allows sending traces and metrics to different endpoints. (#1418)
+- Added Gosec workflow to GitHub Actions (#TBD)
 
 ### Changed
 


### PR DESCRIPTION
## Motivation

Related to https://github.com/open-o11y/opentelemetry-go/pull/7. [Gosec](https://github.com/securego/gosec) is a static analysis engine which scans go source code for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users. 

## Changes

* This PR adds [gosec](https://github.com/securego/gosec) security checks to the repo

**Workflow Triggers**
* pull_requests
* workflow_dispatch (in case maintainers want to trigger a security check manually)
* commits to master

cc- @alolita 