### PR TITLE
Unembed SpanContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed `CloudZoneKey` to `CloudAvailabilityZoneKey` in Resource semantic conventions according to spec. (#1871)
 - The `StatusCode` and `StatusMessage` methods of the `ReadOnlySpan` interface and the `Span` produced by the `go.opentelemetry.io/otel/sdk/trace` package have been replaced with a single `Status` method.
   This method returns the status of a span using the new `Status` type. (#1874)
+- Unembed `SpanContext` in `Link`. (#TBD)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed `CloudZoneKey` to `CloudAvailabilityZoneKey` in Resource semantic conventions according to spec. (#1871)
 - The `StatusCode` and `StatusMessage` methods of the `ReadOnlySpan` interface and the `Span` produced by the `go.opentelemetry.io/otel/sdk/trace` package have been replaced with a single `Status` method.
   This method returns the status of a span using the new `Status` type. (#1874)
-- Unembed `SpanContext` in `Link`. (#TBD)
+- Unembed `SpanContext` in `Link`. (#1877)
 
 ### Deprecated
 

--- a/exporters/otlp/internal/transform/span.go
+++ b/exporters/otlp/internal/transform/span.go
@@ -155,8 +155,8 @@ func links(links []trace.Link) []*tracepb.Span_Link {
 		// being reused -- in short we need a new otLink per iteration.
 		otLink := otLink
 
-		tid := otLink.TraceID()
-		sid := otLink.SpanID()
+		tid := otLink.SpanContext.TraceID()
+		sid := otLink.SpanContext.SpanID()
 
 		sl = append(sl, &tracepb.Span_Link{
 			TraceId:    tid[:],

--- a/exporters/otlp/internal/transform/span_test.go
+++ b/exporters/otlp/internal/transform/span_test.go
@@ -148,7 +148,7 @@ func TestLinks(t *testing.T) {
 	assert.Equal(t, expected, got[1])
 
 	// Changes to our links should not change the produced links.
-	l[1].SpanContext = l[1].WithTraceID(trace.TraceID{})
+	l[1].SpanContext = l[1].SpanContext.WithTraceID(trace.TraceID{})
 	assert.Equal(t, expected, got[1])
 }
 

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -213,8 +213,8 @@ func spanSnapshotToThrift(ss *sdktrace.SpanSnapshot) *gen.Span {
 
 	var refs []*gen.SpanRef
 	for _, link := range ss.Links {
-		tid := link.TraceID()
-		sid := link.SpanID()
+		tid := link.SpanContext.TraceID()
+		sid := link.SpanContext.SpanID()
 		refs = append(refs, &gen.SpanRef{
 			TraceIdHigh: int64(binary.BigEndian.Uint64(tid[0:8])),
 			TraceIdLow:  int64(binary.BigEndian.Uint64(tid[8:16])),

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -555,7 +555,7 @@ type Span interface {
 //      track the relationship.
 type Link struct {
 	// SpanContext of the linked Span.
-	SpanContext
+	SpanContext SpanContext
 
 	// Attributes describe the aspects of the link.
 	Attributes []attribute.KeyValue


### PR DESCRIPTION
Unembed `SpanContext` in `Link` so that `Link` can be correctly Marshaled. Should resolve #1820 .