### PR TITLE
Moved internal/tools duplicated findRepoRoot function to common package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Get` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a `string` instead of an `attribute.Key` type. (#1931)
 - The `Insert` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a pair of `string`s instead of an `attribute.KeyValue` type. (#1931)
 - The `Delete` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a `string` instead of an `attribute.Key` type. (#1931)
+- Moved duplicated func `findRepoRoot` used in `internal/tools` to new package `internal/tools/common` (TBD).
 
 ### Deprecated
 

--- a/internal/tools/common/common.go
+++ b/internal/tools/common/common.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides helper functions used in scripts within the
+// internal/tools module.
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func FindRepoRoot() (string, error) {
+	start, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	dir := start
+	for {
+		_, err := os.Stat(filepath.Join(dir, ".git"))
+		if errors.Is(err, os.ErrNotExist) {
+			dir = filepath.Dir(dir)
+			// From https://golang.org/pkg/path/filepath/#Dir:
+			// The returned path does not end in a separator unless it is the root directory.
+			if strings.HasSuffix(dir, string(filepath.Separator)) {
+				return "", fmt.Errorf("unable to find git repository enclosing working dir %s", start)
+			}
+			continue
+		}
+
+		if err != nil {
+			return "", err
+		}
+
+		return dir, nil
+	}
+}

--- a/internal/tools/crosslink/crosslink.go
+++ b/internal/tools/crosslink/crosslink.go
@@ -35,36 +35,11 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+
+	"go.opentelemetry.io/otel/internal/tools/common"
 )
 
 type repo string
-
-func findRepoRoot() (repo, error) {
-	start, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	dir := start
-	for {
-		_, err := os.Stat(filepath.Join(dir, ".git"))
-		if errors.Is(err, os.ErrNotExist) {
-			dir = filepath.Dir(dir)
-			// From https://golang.org/pkg/path/filepath/#Dir:
-			// The returned path does not end in a separator unless it is the root directory.
-			if strings.HasSuffix(dir, string(filepath.Separator)) {
-				return "", fmt.Errorf("unable to find git repository enclosing working dir %s", start)
-			}
-			continue
-		}
-
-		if err != nil {
-			return "", err
-		}
-
-		return repo(dir), nil
-	}
-}
 
 type mod struct {
 	filePath   string
@@ -157,10 +132,12 @@ func (m mods) crossLink() error {
 }
 
 func main() {
-	repoRoot, err := findRepoRoot()
+	repoRootStr, err := common.FindRepoRoot()
 	if err != nil {
 		log.Fatalf("unable to find repo root: %v", err)
 	}
+
+	repoRoot := repo(repoRootStr)
 
 	mods, err := repoRoot.findModules()
 	if err != nil {

--- a/internal/tools/semconv-gen/generator.go
+++ b/internal/tools/semconv-gen/generator.go
@@ -16,20 +16,20 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
 	flag "github.com/spf13/pflag"
 	"golang.org/x/mod/semver"
+
+	"go.opentelemetry.io/otel/internal/tools/common"
 )
 
 func main() {
@@ -98,7 +98,7 @@ func validateConfig(cfg config) (config, error) {
 	}
 
 	if !path.IsAbs(cfg.outputPath) {
-		root, err := findRepoRoot()
+		root, err := common.FindRepoRoot()
 		if err != nil {
 			return config{}, err
 		}
@@ -158,6 +158,8 @@ func render(cfg config) error {
 		"--template", path.Join("/data", path.Base(cfg.templateFilename)),
 		"--output", path.Join("/data/output", path.Base(cfg.outputFilename)),
 	)
+
+	fmt.Println(cmd)
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("unable to render template: %w", err)
@@ -251,33 +253,6 @@ func checkoutSpecToDir(cfg config, toDir string) (doneFunc func(), err error) {
 	}
 
 	return doneFunc, nil
-}
-
-func findRepoRoot() (string, error) {
-	start, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	dir := start
-	for {
-		_, err := os.Stat(filepath.Join(dir, ".git"))
-		if errors.Is(err, os.ErrNotExist) {
-			dir = filepath.Dir(dir)
-			// From https://golang.org/pkg/path/filepath/#Dir:
-			// The returned path does not end in a separator unless it is the root directory.
-			if strings.HasSuffix(dir, string(filepath.Separator)) {
-				return "", fmt.Errorf("unable to find git repository enclosing working dir %s", start)
-			}
-			continue
-		}
-
-		if err != nil {
-			return "", err
-		}
-
-		return dir, nil
-	}
 }
 
 var capitalizations = []string{

--- a/internal/tools/semconv-gen/generator.go
+++ b/internal/tools/semconv-gen/generator.go
@@ -158,8 +158,6 @@ func render(cfg config) error {
 		"--template", path.Join("/data", path.Base(cfg.templateFilename)),
 		"--output", path.Join("/data/output", path.Base(cfg.outputFilename)),
 	)
-
-	fmt.Println(cmd)
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("unable to render template: %w", err)


### PR DESCRIPTION
Minor refactoring of internal/tools scripts, as we will be using the new FindRepoRoot function in several tooling scripts.

Change overview
- Created a package with import path "go.opentelemetry.io/otel/internal/tools/common" with func FindRepoRoot() to return string. 
- Added a line in crosslink to convert outputted string to type repo.