### PR TITLE
Add Float64CounterObserver and Float64UpDownCounterObserver Tests

### DIFF
--- a/exporters/prometheus/prometheus_test.go
+++ b/exporters/prometheus/prometheus_test.go
@@ -124,11 +124,11 @@ func TestPrometheusExporter(t *testing.T) {
 
 	expected = append(expected, expectCounter("counter", `counter{A="B",C="D",R="V"} 15.3`))
 
-	_ = metric.Must(meter).NewInt64GaugeObserver("intobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = metric.Must(meter).NewInt64GaugeObserver("intgaugeobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(1, labels...)
 	})
 
-	expected = append(expected, expectGauge("intobserver", `intobserver{A="B",C="D",R="V"} 1`))
+	expected = append(expected, expectGauge("intgaugeobserver", `intgaugeobserver{A="B",C="D",R="V"} 1`))
 
 	histogram.Record(ctx, -0.6, labels...)
 	histogram.Record(ctx, -0.4, labels...)
@@ -147,6 +147,18 @@ func TestPrometheusExporter(t *testing.T) {
 	upDownCounter.Add(ctx, -3.2, labels...)
 
 	expected = append(expected, expectGauge("updowncounter", `updowncounter{A="B",C="D",R="V"} 6.8`))
+
+	_ = metric.Must(meter).NewFloat64CounterObserver("floatcounterobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+		result.Observe(7.7, labels...)
+	})
+
+	expected = append(expected, expectCounter("floatcounterobserver", `floatcounterobserver{A="B",C="D",R="V"} 7.7`))
+
+	_ = metric.Must(meter).NewFloat64UpDownCounterObserver("floatupdowncounterobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+		result.Observe(-7.7, labels...)
+	})
+
+	expected = append(expected, expectGauge("floatupdowncounterobserver", `floatupdowncounterobserver{A="B",C="D",R="V"} -7.7`))
 
 	compareExport(t, exporter, expected)
 	compareExport(t, exporter, expected)


### PR DESCRIPTION
This PR addresses [#2466](https://github.com/open-telemetry/opentelemetry-go/issues/2466) and adds tests for the `Float64CounterObserver` and `Float64UpDownCounterObserver` instruments, meaning all six instrument kinds will be tested.